### PR TITLE
Section 17 minimal api repr

### DIFF
--- a/src/Services/Ordering/Ordering.API/DependancyInjection.cs
+++ b/src/Services/Ordering/Ordering.API/DependancyInjection.cs
@@ -1,4 +1,5 @@
-﻿using Carter;
+﻿using BuildingBlocks.Exceptions.Handler;
+using Carter;
 
 namespace Ordering.API
 {
@@ -8,6 +9,8 @@ namespace Ordering.API
         {
             services.AddCarter();
 
+            services.AddExceptionHandler<CustomExceptionHandler>();
+
             // Add application services here
             return services;
         }
@@ -15,6 +18,8 @@ namespace Ordering.API
         public static WebApplication UseApiServices(this WebApplication app)
         {
             app.MapCarter();
+
+            app.UseExceptionHandler(options => { });
 
             return app;
         }

--- a/src/Services/Ordering/Ordering.API/DependancyInjection.cs
+++ b/src/Services/Ordering/Ordering.API/DependancyInjection.cs
@@ -1,18 +1,21 @@
-﻿namespace Ordering.API
+﻿using Carter;
+
+namespace Ordering.API
 {
     public static class DependancyInjection
     {
         public static IServiceCollection AddApiServices(this IServiceCollection services)
         {
-            // Add Carter.
-            
+            services.AddCarter();
+
             // Add application services here
             return services;
         }
 
         public static WebApplication UseApiServices(this WebApplication app)
         {
-            // Configure the HTTP request pipeline.
+            app.MapCarter();
+
             return app;
         }
     }

--- a/src/Services/Ordering/Ordering.API/DependancyInjection.cs
+++ b/src/Services/Ordering/Ordering.API/DependancyInjection.cs
@@ -1,15 +1,19 @@
 ﻿using BuildingBlocks.Exceptions.Handler;
 using Carter;
+using HealthChecks.UI.Client;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 
 namespace Ordering.API
 {
     public static class DependancyInjection
     {
-        public static IServiceCollection AddApiServices(this IServiceCollection services)
+        public static IServiceCollection AddApiServices(this IServiceCollection services, IConfiguration configuration)
         {
             services.AddCarter();
 
             services.AddExceptionHandler<CustomExceptionHandler>();
+            services.AddHealthChecks()
+                .AddSqlServer(configuration.GetConnectionString("Database")!);
 
             // Add application services here
             return services;
@@ -20,6 +24,11 @@ namespace Ordering.API
             app.MapCarter();
 
             app.UseExceptionHandler(options => { });
+            app.UseHealthChecks("/health",
+                new HealthCheckOptions
+                {
+                    ResponseWriter = UIResponseWriter.WriteHealthCheckUIResponse
+                });
 
             return app;
         }

--- a/src/Services/Ordering/Ordering.API/Endpoints/CreateOrder.cs
+++ b/src/Services/Ordering/Ordering.API/Endpoints/CreateOrder.cs
@@ -1,0 +1,6 @@
+﻿namespace Ordering.API.Endpoints
+{
+    public class CreateOrder
+    {
+    }
+}

--- a/src/Services/Ordering/Ordering.API/Endpoints/CreateOrder.cs
+++ b/src/Services/Ordering/Ordering.API/Endpoints/CreateOrder.cs
@@ -1,6 +1,29 @@
-﻿namespace Ordering.API.Endpoints
+﻿using Ordering.Application.Orders.Commands.CreateOrder;
+
+namespace Ordering.API.Endpoints
 {
-    public class CreateOrder
+    public record CreateOrderRequest(OrderDto Order);
+    public record CreateOrderResponse(Guid Id);
+
+    public class CreateOrder : ICarterModule
     {
+        public void AddRoutes(IEndpointRouteBuilder app)
+        {
+            app.MapPost("/orders", async (CreateOrderRequest request, ISender sender) =>
+            {
+                var command = request.Adapt<CreateOrderCommand>();
+
+                var result = await sender.Send(command);
+
+                var response = result.Adapt<CreateOrderResponse>();
+
+                return Results.Created($"/orders/{response.Id}", response);
+            })
+            .WithName("CreateOrder")
+            .Produces<CreateOrderResponse>(StatusCodes.Status201Created)
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .WithSummary("Create order")
+            .WithDescription("Create Order");
+        }
     }
 }

--- a/src/Services/Ordering/Ordering.API/Endpoints/DeleteOrder.cs
+++ b/src/Services/Ordering/Ordering.API/Endpoints/DeleteOrder.cs
@@ -1,0 +1,6 @@
+﻿namespace Ordering.API.Endpoints
+{
+    public class DeleteOrder
+    {
+    }
+}

--- a/src/Services/Ordering/Ordering.API/Endpoints/DeleteOrder.cs
+++ b/src/Services/Ordering/Ordering.API/Endpoints/DeleteOrder.cs
@@ -1,6 +1,26 @@
-﻿namespace Ordering.API.Endpoints
+﻿
+using Ordering.Application.Orders.Commands.DeleteOrder;
+
+namespace Ordering.API.Endpoints
 {
-    public class DeleteOrder
+    public record DeleteOrderResponse(bool isSuccess);
+
+    public class DeleteOrder : ICarterModule
     {
+        public void AddRoutes(IEndpointRouteBuilder app)
+        {
+            app.MapDelete("/orders/{id:guid}", async (Guid id, ISender sender) =>
+            {
+                var command = new DeleteOrderCommand(id);
+                var response = await sender.Send(command);
+                var result = response.Adapt<DeleteOrderResponse>();
+                return Results.Ok(result);
+            })
+            .WithName("DeleteOrder")
+            .Produces<DeleteOrderResponse>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .WithSummary("Delete order")
+            .WithDescription("Delete Order");
+        }
     }
 }

--- a/src/Services/Ordering/Ordering.API/Endpoints/DeleteOrder.cs
+++ b/src/Services/Ordering/Ordering.API/Endpoints/DeleteOrder.cs
@@ -3,7 +3,7 @@ using Ordering.Application.Orders.Commands.DeleteOrder;
 
 namespace Ordering.API.Endpoints
 {
-    public record DeleteOrderResponse(bool isSuccess);
+    public record DeleteOrderResponse(bool IsSuccess);
 
     public class DeleteOrder : ICarterModule
     {
@@ -12,9 +12,9 @@ namespace Ordering.API.Endpoints
             app.MapDelete("/orders/{id:guid}", async (Guid id, ISender sender) =>
             {
                 var command = new DeleteOrderCommand(id);
-                var response = await sender.Send(command);
-                var result = response.Adapt<DeleteOrderResponse>();
-                return Results.Ok(result);
+                var result = await sender.Send(command);
+                var response = new DeleteOrderResponse(result.Success);
+                return Results.Ok(response);
             })
             .WithName("DeleteOrder")
             .Produces<DeleteOrderResponse>(StatusCodes.Status200OK)

--- a/src/Services/Ordering/Ordering.API/Endpoints/GetOrders.cs
+++ b/src/Services/Ordering/Ordering.API/Endpoints/GetOrders.cs
@@ -1,0 +1,6 @@
+﻿namespace Ordering.API.Endpoints
+{
+    public class GetOrders
+    {
+    }
+}

--- a/src/Services/Ordering/Ordering.API/Endpoints/GetOrders.cs
+++ b/src/Services/Ordering/Ordering.API/Endpoints/GetOrders.cs
@@ -1,6 +1,25 @@
-﻿namespace Ordering.API.Endpoints
+﻿using BuildingBlocks.Pagination;
+using Ordering.Application.Orders.Query.GetOrders;
+
+namespace Ordering.API.Endpoints
 {
-    public class GetOrders
+    public record GetOrdersResponse(PaginationResult<OrderDto> Orders);
+
+    public class GetOrders : ICarterModule
     {
+        public void AddRoutes(IEndpointRouteBuilder app)
+        {
+            app.MapGet("/orders", async ([AsParameters] PaginationRequest request, ISender sender) =>
+            {
+                var result = await sender.Send(new GetOrdersQuery(request));
+                var response = result.Adapt<GetOrdersResponse>();
+                return Results.Ok(response);
+            })
+            .WithName("GetOrders")
+            .Produces<GetOrdersResponse>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .WithSummary("Get orders")
+            .WithDescription("Get orders");
+        }
     }
 }

--- a/src/Services/Ordering/Ordering.API/Endpoints/GetOrdersByCustomer.cs
+++ b/src/Services/Ordering/Ordering.API/Endpoints/GetOrdersByCustomer.cs
@@ -1,0 +1,6 @@
+﻿namespace Ordering.API.Endpoints
+{
+    public class GetOrdersByCustomer
+    {
+    }
+}

--- a/src/Services/Ordering/Ordering.API/Endpoints/GetOrdersByCustomer.cs
+++ b/src/Services/Ordering/Ordering.API/Endpoints/GetOrdersByCustomer.cs
@@ -1,6 +1,26 @@
-﻿namespace Ordering.API.Endpoints
+﻿
+using Ordering.Application.Orders.Query.GetOrdersByCustomer;
+
+namespace Ordering.API.Endpoints
 {
-    public class GetOrdersByCustomer
+    public record GetOrderByCustomerResponse(IEnumerable<OrderDto> Orders);
+
+    public class GetOrdersByCustomer : ICarterModule
     {
+        public void AddRoutes(IEndpointRouteBuilder app)
+        {
+            app.MapGet("/orders/customer/{customerId:guid}", async (Guid customerId, ISender sender) =>
+            {
+                var query = new GetOrdersByCustomerQuery(customerId);
+                var result = await sender.Send(query);
+                var response = result.Adapt<GetOrderByCustomerResponse>();
+                return Results.Ok(response);
+            })
+            .WithName("GetOrdersByCustomer")
+            .Produces<GetOrderByCustomerResponse>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .WithSummary("Get orders by customer id")
+            .WithDescription("Get orders by customer id");
+        }
     }
 }

--- a/src/Services/Ordering/Ordering.API/Endpoints/GetOrdersByName.cs
+++ b/src/Services/Ordering/Ordering.API/Endpoints/GetOrdersByName.cs
@@ -1,0 +1,6 @@
+﻿namespace Ordering.API.Endpoints
+{
+    public class GetOrdersByName
+    {
+    }
+}

--- a/src/Services/Ordering/Ordering.API/Endpoints/GetOrdersByName.cs
+++ b/src/Services/Ordering/Ordering.API/Endpoints/GetOrdersByName.cs
@@ -1,6 +1,26 @@
-﻿namespace Ordering.API.Endpoints
+﻿
+using Ordering.Application.Orders.Query.GetOrdersByName;
+
+namespace Ordering.API.Endpoints
 {
-    public class GetOrdersByName
+    public record GetOrdersByNameResponse(IEnumerable<OrderDto> Orders);
+
+    public class GetOrdersByName : ICarterModule
     {
+        public void AddRoutes(IEndpointRouteBuilder app)
+        {
+            app.MapGet("/orders/{userName}", async (string userName, ISender sender) =>
+            {
+                var query = new GetOrdersByNameQuery(userName);
+                var orders = await sender.Send(query);
+                var response = new GetOrdersByNameResponse(orders.Adapt<IEnumerable<OrderDto>>());
+                return Results.Ok(response);
+            })
+            .WithName("GetOrdersByName")
+            .Produces<GetOrdersByNameResponse>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .WithSummary("Get orders by user name")
+            .WithDescription("Get orders by user name");
+        }
     }
 }

--- a/src/Services/Ordering/Ordering.API/Endpoints/GetOrdersByName.cs
+++ b/src/Services/Ordering/Ordering.API/Endpoints/GetOrdersByName.cs
@@ -12,8 +12,8 @@ namespace Ordering.API.Endpoints
             app.MapGet("/orders/{userName}", async (string userName, ISender sender) =>
             {
                 var query = new GetOrdersByNameQuery(userName);
-                var orders = await sender.Send(query);
-                var response = new GetOrdersByNameResponse(orders.Adapt<IEnumerable<OrderDto>>());
+                var result = await sender.Send(query);
+                var response = new GetOrdersByNameResponse(result.Orders);
                 return Results.Ok(response);
             })
             .WithName("GetOrdersByName")

--- a/src/Services/Ordering/Ordering.API/Endpoints/UpdateOrder.cs
+++ b/src/Services/Ordering/Ordering.API/Endpoints/UpdateOrder.cs
@@ -1,0 +1,6 @@
+﻿namespace Ordering.API.Endpoints
+{
+    public class UpdateOrder
+    {
+    }
+}

--- a/src/Services/Ordering/Ordering.API/Endpoints/UpdateOrder.cs
+++ b/src/Services/Ordering/Ordering.API/Endpoints/UpdateOrder.cs
@@ -1,6 +1,30 @@
-﻿namespace Ordering.API.Endpoints
+﻿
+using Ordering.Application.Orders.Commands.UpdateOrder;
+
+namespace Ordering.API.Endpoints
 {
-    public class UpdateOrder
+    public record UpdateOrderRequest(OrderDto Order);
+    public record UpdateOrderResponse(bool isSuccess);
+
+    public class UpdateOrder : ICarterModule
     {
+        public void AddRoutes(IEndpointRouteBuilder app)
+        {
+            app.MapPut("/orders", async (UpdateOrderRequest request, ISender sender) =>
+            {
+                var command = request.Adapt<UpdateOrderCommand>();
+
+                var response = await sender.Send(command);
+
+                var result = response.Adapt<UpdateOrderResponse>();
+
+                return Results.Ok(result);
+            })
+            .WithName("UpdateOrder")
+            .Produces<UpdateOrderResponse>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .WithSummary("Update order")
+            .WithDescription("Update Order");
+        }
     }
 }

--- a/src/Services/Ordering/Ordering.API/GlobalUsuings.cs
+++ b/src/Services/Ordering/Ordering.API/GlobalUsuings.cs
@@ -1,0 +1,4 @@
+﻿global using Carter;
+global using Mapster;
+global using MediatR;
+global using Ordering.Application.Dtos;

--- a/src/Services/Ordering/Ordering.API/Ordering.API.csproj
+++ b/src/Services/Ordering/Ordering.API/Ordering.API.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Carter" Version="8.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.12">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Services/Ordering/Ordering.API/Ordering.API.csproj
+++ b/src/Services/Ordering/Ordering.API/Ordering.API.csproj
@@ -10,6 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="8.0.0" />
+    <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="8.0.0" />
     <PackageReference Include="Carter" Version="8.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.12">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Services/Ordering/Ordering.API/Program.cs
+++ b/src/Services/Ordering/Ordering.API/Program.cs
@@ -9,7 +9,7 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services
     .AddApplicationServices()
     .AddInfrastructureServices(builder.Configuration)
-    .AddApiServices();
+    .AddApiServices(builder.Configuration);
 
 var app = builder.Build();
 

--- a/src/Services/Ordering/Ordering.Application/Orders/Query/GetOrdersByName/GetOrdersByNameHandler.cs
+++ b/src/Services/Ordering/Ordering.Application/Orders/Query/GetOrdersByName/GetOrdersByNameHandler.cs
@@ -13,8 +13,8 @@ public class GetOrdersByNameHandler(IApplicationDbContext dbContext)
             .Include(x => x.OrderItems)
             .AsNoTracking()
             .Where(x => x.OrderName.Value.Contains(query.Name))
-            .OrderBy(x => x.OrderName)
-            .ToListAsync();
+            .OrderBy(x => x.OrderName.Value)
+            .ToListAsync(cancellationToken);
 
         return new GetOrdersByNameResult(orders.ToOrderDtoList());
     }


### PR DESCRIPTION
# Section 17: Minimal API with REPR Pattern for Ordering Service

## Summary

This PR implements minimal API endpoints for the Ordering microservice using the REPR (Request-Endpoint-Response) pattern with Carter library, replacing the traditional controller-based approach.

## Changes

### API Infrastructure

**`DependancyInjection.cs`**
- Registers Carter for endpoint discovery
- Configures custom exception handler
- Adds SQL Server health checks at `/health` endpoint

**`Program.cs`**
- Simplified startup using extension methods
- Calls `AddApiServices()` and `UseApiServices()` for clean separation

**`GlobalUsuings.cs`**
- Added global usings for `Carter`, `Mapster`, `MediatR`, and `OrderDto`

**`Ordering.API.csproj`**
- Added `Carter` (8.0.0) for minimal API endpoints
- Added `AspNetCore.HealthChecks.SqlServer` and `AspNetCore.HealthChecks.UI.Client` (8.0.0)

### Endpoints (6 new endpoints)

| Endpoint | Method | Route | Description |
|----------|--------|-------|-------------|
| `CreateOrder` | POST | `/orders` | Creates new order from `OrderDto` request |
| `GetOrders` | GET | `/orders` | Retrieves paginated list of orders |
| `GetOrdersByCustomer` | GET | `/orders/customer/{customerId:guid}` | Retrieves all orders for a specific customer |
| `GetOrdersByName` | GET | `/orders/{userName}` | Retrieves orders by order name (contains search) |
| `UpdateOrder` | PUT | `/orders` | Updates existing order |
| `DeleteOrder` | DELETE | `/orders/{id:guid}` | Deletes order by ID |

### Bug Fixes

**`GetOrdersByNameHandler.cs`**
- Fixed EF Core LINQ translation error: changed `.OrderBy(x => x.OrderName)` to `.OrderBy(x => x.OrderName.Value)` for complex type ordering
- Added `CancellationToken` propagation to `ToListAsync()`

**`DeleteOrder.cs`**
- Fixed Mapster mapping issue: property name mismatch between `Success` and `isSuccess`
- Now uses direct property access instead of Mapster adaptation

**`GetOrdersByName.cs`**
- Fixed invalid cast exception: uses `result.Orders` directly instead of attempting to adapt the entire result object

## Architecture

- **REPR Pattern**: Each endpoint is a self-contained class implementing `ICarterModule`
- **CQRS**: Commands and queries handled via MediatR
- **Mapping**: Mapster for DTO transformations
- **Health Checks**: SQL Server connectivity monitoring

## Files Changed

```
src/Services/Ordering/Ordering.API/DependancyInjection.cs
src/Services/Ordering/Ordering.API/Endpoints/CreateOrder.cs
src/Services/Ordering/Ordering.API/Endpoints/DeleteOrder.cs
src/Services/Ordering/Ordering.API/Endpoints/GetOrders.cs
src/Services/Ordering/Ordering.API/Endpoints/GetOrdersByCustomer.cs
src/Services/Ordering/Ordering.API/Endpoints/GetOrdersByName.cs
src/Services/Ordering/Ordering.API/Endpoints/UpdateOrder.cs
src/Services/Ordering/Ordering.API/GlobalUsuings.cs
src/Services/Ordering/Ordering.API/Ordering.API.csproj
src/Services/Ordering/Ordering.API/Program.cs
src/Services/Ordering/Ordering.Application/Orders/Query/GetOrdersByName/GetOrdersByNameHandler.cs
```
